### PR TITLE
wrong fluorine atom type in FB - SB - OB/NB bond-angle of bis(fluorosulfonyl)amide force field

### DIFF
--- a/il.ff
+++ b/il.ff
@@ -260,8 +260,8 @@ SB  NB  SB   harm   125.6   671.0
 SB  CF  CF   harm   115.9   418.4
 FB  CF  CF   harm   109.5   418.4
 # bis(fluorosulfonyl)amide
-F   SB  OB   harm   104.1  1077.0
-F   SB  NB   harm   103.0   902.0   
+FB  SB  OB   harm   104.1  1077.0
+FB  SB  NB   harm   103.0   902.0
 # dicyanamide JPCB110(2006)19586
 CZ  N3  CZ   harm   118.5   362.0
 N3  CZ  NZ   harm   175.2   425.0


### PR DESCRIPTION
Hi Agilio,

the fluorine atom type in the bond-angle definition in the bis(fluorosulfonyl)amide force field appears to be wrong. According to the Z-matrix file fsi.zmat it should be FB and not F (as it is now). In test simulations this change corrects spurious dynamics I observed with the missing angle (overlapping fluorine and sulfur of sulfonyl groups). Without this change fftool also complains about the missing angle when preparing simulations including FSI-.

Not sure if this conflicts with something else in the force fields.

HTH and cheers,

Frank